### PR TITLE
Boot components in DOMContentLoaded event

### DIFF
--- a/lib/strategies/mutation_observer.js
+++ b/lib/strategies/mutation_observer.js
@@ -66,8 +66,8 @@ export function defineElement (
   observers[name] = true
 
   window.addEventListener('DOMContentLoaded', () => {
-    const node = document.querySelector(name);
-    if (node) checkForMount(node, name, events);
+    const nodes = document.getElementsByTagName(name);
+    [...nodes].forEach(node => checkForMount(node, name, events))
   });
 }
 

--- a/lib/strategies/mutation_observer.js
+++ b/lib/strategies/mutation_observer.js
@@ -64,6 +64,11 @@ export function defineElement (
   })
 
   observers[name] = true
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const node = document.querySelector(name);
+    if (node) checkForMount(node, name, events);
+  });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remount",
   "description": "Mount React components to the DOM using custom elements",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "author": "Rico Sta. Cruz <rstacruz@users.noreply.github.com>",
   "bugs": {
     "url": "https://github.com/rstacruz/remount/issues"


### PR DESCRIPTION
> The [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) interface provides the ability to watch for changes being made to the DOM tree. It is designed as a replacement for the older Mutation Events feature which was part of the DOM3 Events specification.

When you have a page with a custom tag, the DOM not suffer changes. Nothing happens. So it's needs a boot to component.