### PR TITLE
Fix Webpacker compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 > Apr 22, 2019
 
 - Add a workaround for React elements in Shadow DOM mode. ([#8], [@rybon])
-- Fix compatibility with Webpacker by making the main export `.js` instead of `.mjs`
-- Deprecate importing using `import remount from 'remount/esm'` - just use `'remount'` instead.
+- Fix compatibility with Webpacker by making the main export `.js` instead of `.mjs`. ([#11])
+- Deprecate importing using `import remount from 'remount/esm'` - just use `'remount'` instead. ([#11])
 
 [#8]: https://github.com/rstacruz/remount/pull/8
+[#11]: https://github.com/rstacruz/remount/pull/11
 [@rybon]: https://github.com/rybon
 [v0.10.0]: https://github.com/rstacruz/remount/compare/v0.9.5...v0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## Pre-v1.0.0 changes
+## [v0.10.0]
+
+> Apr 22, 2019
+
+- Add a workaround for React elements in Shadow DOM mode. ([#8], [@rybon])
+
+[#8]: https://github.com/rstacruz/remount/pull/8
+[@rybon]: https://github.com/rybon
+[v0.10.0]: https://github.com/rstacruz/remount/compare/v0.9.5...v0.10.0
+
+## v0.1 to v0.9
 
 [v0.9.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 > Apr 22, 2019
 
 - Add a workaround for React elements in Shadow DOM mode. ([#8], [@rybon])
+- Fix compatibility with Webpacker by making the main export `.js` instead of `.mjs`
+- Deprecate importing using `import remount from 'remount/esm'` - just use `'remount'` instead.
 
 [#8]: https://github.com/rstacruz/remount/pull/8
 [@rybon]: https://github.com/rybon

--- a/docs/builds.md
+++ b/docs/builds.md
@@ -4,16 +4,16 @@ Remount comes in 3 flavors:
 
 | Version       | Description                           |
 | ------------- | ------------------------------------- |
-| `remount/es5` | Supports legacy browsers (default)    |
+| `remount`     | ES Modules build - the default        |
+| `remount/es5` | CommonJS build                        |
 | `remount/es6` | Uses classes and other ES2015+ syntax |
-| `remount/esm` | es modules .mjs build                 |
 
 ## Using builds
 
-You can use them like so:
+If you'd like to use an alternate build, you can import from it like so:
 
 ```js
-import { define } from 'remount/es6'
+import { define } from 'remount/es5'
 ```
 
 Or if you're using Webpack:
@@ -24,7 +24,7 @@ module.exports = {
   /* ... */
   resolve: {
     alias: {
-      remount: 'remount/es6'
+      remount: 'remount/es5'
     }
   }
 }
@@ -35,7 +35,5 @@ module.exports = {
 When used like so, Remount will be available as `window.Remount`. Great for using in JSFiddle/Codepen.
 
 ```js
-<script src='https://cdn.jsdelivr.net/npm/remount'></script>
-<script src='https://cdn.jsdelivr.net/npm/remount/dist/remount.es6.js'></script>
-<script src='https://cdn.jsdelivr.net/npm/remount/dist/remount.esm.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/remount/dist/remount.es5.js' />
 ```

--- a/esm.mjs
+++ b/esm.mjs
@@ -1,1 +1,0 @@
-export * from './dist/remount.esm.mjs'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dist/remount.*",
     "es5.js",
     "es6.js",
-    "esm.mjs"
+    "esm.js"
   ],
   "homepage": "https://github.com/rstacruz/remount#readme",
   "jest": {
@@ -62,7 +62,7 @@
   ],
   "license": "MIT",
   "main": "dist/remount.es5.js",
-  "module": "dist/remount.esm.mjs",
+  "module": "dist/remount.js",
   "peerDependencies": {
     "react": ">= 15.0.0",
     "react-dom": ">= 15.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,13 +54,13 @@ export default [
   // ES Modules
   {
     ...DEFAULTS,
-    output: { file: 'dist/remount.esm.mjs', format: 'esm' }
+    output: { file: 'dist/remount.js', format: 'esm' }
   },
 
   {
     ...DEFAULTS,
     plugins: [MINIFY],
-    output: { file: 'dist/remount.esm.min.mjs', format: 'esm' }
+    output: { file: 'dist/remount.min.js', format: 'esm' }
   },
 
   // ES6


### PR DESCRIPTION
This fixes compatibility with Rails's Webpacker by making the main export `.js` instead of `.mjs`.

This also deprecates the `'remount/esm'` import; it's the default, so just use `'remount'`.
