### PR TITLE
Fix IE11 / Edge error

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -30,7 +30,7 @@ export function update(elSpec, mountPoint, props, element) {
   const { component } = elSpec
   const reactElement = React.createElement(component, props)
   ReactDOM.render(reactElement, mountPoint)
-  if (element) {
+  if (element && element.shadowRoot) {
     retargetEvents(element.shadowRoot)
   }
 }


### PR DESCRIPTION
These browsers don't use Shadow DOM mode anyway, so no retargeting needed.