### PR TITLE
fixed #90

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,4 @@ jobs:
         cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - run: yarn test
-    - run: yarn tsc --noEmit
+    - run: yarn tsc --noEmit --emitDeclarationOnly false

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "license": "MIT",
   "main": "dist/remount.es5.js",
   "module": "dist/remount.js",
+  "types": "dist/index.d.ts",
   "peerDependencies": {
     "react": ">= 18.0.0",
     "react-dom": ">= 18.0.0"
@@ -70,6 +71,7 @@
   },
   "scripts": {
     "build": "rollup --config",
+    "postbuild": "run-s tsc",
     "prettier": "prettier '*.js' 'src/**/*.{js,ts}'",
     "tsc": "tsc",
     "jest": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "compilerOptions": {
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist",
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    "noEmit": false,
     "target": "es5",
     "lib": [
       "dom",
@@ -16,7 +26,6 @@
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "preserve"
   },
   "include": [


### PR DESCRIPTION
This pull request:
- Fixes #90
- Adds `types` field to package.json, as [described in the TypeScript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)
- Recreates the TypeScript definitions after every build so that they stay in sync
- Updates the GitHub Actions workflow from `yarn tsc --noEmit` to `yarn tsc --noEmit --emitDeclarationOnly false` to maintain the same functionality even with the `tsconfig.json` changes